### PR TITLE
Fix renewals sorting being deprecated in sendCall constructor

### DIFF
--- a/app/Mail/sendCall.php
+++ b/app/Mail/sendCall.php
@@ -16,7 +16,10 @@ class sendCall extends Mailable
 
     public function __construct(public $step, $renewals, public $validity_date, public $instruction_date, public $total, public $total_ht, public $subject, public $dest)
     {
-        $this->renewals = collect($renewals)->sortBy(['caseref', 'asc'], ['country', 'asc']);
+        $this->renewals = collect($renewals)->sortBy([
+            ['caseref', 'asc'],
+            ['country', 'asc']
+        ]);
         // Added to ask for receipt confirmation
         $this->callbacks[] = (function ($message) {
             $message->getHeaders()->addTextHeader('X-Confirm-Reading-To', '<'.Auth::user()->email.'>');


### PR DESCRIPTION
Hi!

Since Laravel v10.47.0, `sortByMany` inherits from the options passed as the second parameter of `sortBy`.

Passing a second array in the `sortBy` method weren't a problem until v10.47.0 because this parameter is not typed (_so no error because it should be an int_) and isn't passed to `sortByMany`.

By the way, the renewals weren't filtered by country because the right syntax for this method is passing a multi-dimensional array as first parameter.

This fixes the issue #130 as Claire's phpIP is on v10.47.0.

Tell me if it's all good!