### PR TITLE
feat(DocumentMergeService): Add missing actors field for file merge, …

### DIFF
--- a/app/Http/Controllers/MatterController.php
+++ b/app/Http/Controllers/MatterController.php
@@ -686,7 +686,9 @@ class MatterController extends Controller
     public function mergeFile(Matter $matter, MergeFileRequest $request)
     {
         $file = $request->file('file');
-        $template = $this->documentMergeService->merge($matter, $file->path());
+        $template = $this->documentMergeService
+            ->setMatter($matter)
+            ->merge($file->path());
 
         return response()->streamDownload(function () use ($template) {
             $template->saveAs('php://output');

--- a/app/Models/Actor.php
+++ b/app/Models/Actor.php
@@ -35,6 +35,11 @@ class Actor extends Model
         return $this->belongsToMany(Matter::class, 'matter_actor_lnk');
     }
 
+    public function mattersWithLnk()
+    {
+        return $this->hasMany(ActorPivot::class, 'actor_id');
+    }
+
     public function droleInfo()
     {
         return $this->belongsTo(Role::class, 'default_role');

--- a/app/Models/ActorPivot.php
+++ b/app/Models/ActorPivot.php
@@ -4,35 +4,69 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
+/**
+ * Class ActorPivot
+ *
+ * Represents the pivot table for the many-to-many relationship between Matter and Actor models.
+ */
 class ActorPivot extends Pivot
 {
+    /**
+     * @var string The table associated with the pivot model.
+     */
     protected $table = 'matter_actor_lnk';
 
+    /**
+     * @var array The attributes that should be hidden for arrays.
+     */
     protected $hidden = ['creator', 'created_at', 'updated_at', 'updater'];
 
+    /**
+     * @var array The attributes that aren't mass assignable.
+     */
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
+    /**
+     * @var array The relationships that should be touched on save.
+     */
     protected $touches = ['matter'];
-    /*protected $casts = [
-        'date' => 'date:Y-m-d'
-    ];*/
 
-    public function matter()
+    /**
+     * Get the matter that owns the pivot.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function matter(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
-        return $this->belongsTo(Matter::class);
+        return $this->belongsTo(Matter::class, 'matter_id');
     }
 
-    public function actor()
+    /**
+     * Get the actor that owns the pivot.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function actor(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
-        return $this->belongsTo(Actor::class);
+        return $this->belongsTo(Actor::class, 'actor_id');
     }
 
-    public function role()
+    /**
+     * Get the role associated with the pivot.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function role(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(Role::class, 'role');
     }
 
-    public function company()
+    /**
+     * Get the company associated with the pivot.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function company(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(Actor::class, 'company_id');
     }

--- a/app/Models/Matter.php
+++ b/app/Models/Matter.php
@@ -77,12 +77,12 @@ class Matter extends Model
         return $this->hasOne(MatterActors::class)->whereRoleCode('CLI')->whereShared(1)->withDefault();
     }
 
-    public function payer()
+    public function payor()
     {
         return $this->hasOne(MatterActors::class)->whereRoleCode('PAY')->withDefault();
     }
 
-    public function sharedPayer()
+    public function sharedPayor()
     {
         return $this->hasOne(MatterActors::class)->whereRoleCode('PAY')->whereShared(1)->withDefault();
     }
@@ -112,7 +112,7 @@ class Matter extends Model
 
     public function sharedApplicantsFromLnk()
     {
-        return $this->belongsToMany(Actor::class, 'matter_actor_lnk', 'matter_id', 'actor_id', 'container_id', '')
+        return $this->belongsToMany(Actor::class, 'matter_actor_lnk', 'matter_id', 'actor_id', 'container_id')
             ->using(ActorPivot::class)
             ->withPivot('role', 'display_order', 'shared', 'actor_ref')
             ->wherePivot('role', 'APP')
@@ -129,7 +129,7 @@ class Matter extends Model
 
     public function sharedOwners()
     {
-        return $this->belongsToMany(Actor::class, 'matter_actor_lnk', 'matter_id', 'actor_id', 'container_id', '')
+        return $this->belongsToMany(Actor::class, 'matter_actor_lnk', 'matter_id', 'actor_id', 'container_id')
             ->using(ActorPivot::class)
             ->withPivot('role', 'display_order', 'shared', 'actor_ref')
             ->wherePivot('role', 'OWN')
@@ -150,6 +150,32 @@ class Matter extends Model
             ->wherePivot('role', 'AGT');
     }
 
+    public function sharedAgents()
+    {
+        return $this->belongsToMany(Actor::class, 'matter_actor_lnk', 'matter_id', 'actor_id', 'container_id')
+            ->using(ActorPivot::class)
+            ->withPivot('role', 'display_order', 'shared', 'actor_ref')
+            ->wherePivot('role', 'AGT')
+            ->wherePivot('shared', 1);
+    }
+
+    public function secondaryAgents()
+    {
+        return $this->belongsToMany(Actor::class, 'matter_actor_lnk', 'matter_id', 'actor_id')
+            ->using(ActorPivot::class)
+            ->withPivot('role', 'display_order', 'shared', 'actor_ref')
+            ->wherePivot('role', 'AGT2');
+    }
+
+    public function sharedSecondaryAgents()
+    {
+        return $this->belongsToMany(Actor::class, 'matter_actor_lnk', 'matter_id', 'actor_id', 'container_id')
+            ->using(ActorPivot::class)
+            ->withPivot('role', 'display_order', 'shared', 'actor_ref')
+            ->wherePivot('role', 'AGT2')
+            ->wherePivot('shared', 1);
+    }
+
     public function writers()
     {
         return $this->hasMany(MatterActors::class)
@@ -162,6 +188,15 @@ class Matter extends Model
             ->using(ActorPivot::class)
             ->withPivot('role', 'display_order', 'shared', 'actor_ref')
             ->wherePivot('role', 'ANN');
+    }
+
+    public function sharedAnnuityAgents()
+    {
+        return $this->belongsToMany(Actor::class, 'matter_actor_lnk', 'matter_id', 'actor_id', 'container_id')
+            ->using(ActorPivot::class)
+            ->withPivot('role', 'display_order', 'shared', 'actor_ref')
+            ->wherePivot('role', 'ANN')
+            ->wherePivot('shared', 1);
     }
 
     public function responsibles(): \Illuminate\Database\Eloquent\Relations\HasMany
@@ -693,18 +728,18 @@ class Matter extends Model
         if($client && $client->address_billing) {
             return collect([
                 collect([
-                    $this->payer->actor?->name,
-                    $this->sharedPayer->actor?->name,
+                    $this->payor->actor?->name,
+                    $this->sharedPayor->actor?->name,
                 ]),
                 collect([
-                    $this->payer->actor?->address,
-                    $this->sharedPayer->actor?->address,
+                    $this->payor->actor?->address,
+                    $this->sharedPayor->actor?->address,
                     $this->client->actor?->address_billing,
                     $this->sharedClient->actor?->address_billing
                 ]),
                 collect([
-                    $this->payer->actor?->country,
-                    $this->sharedPayer->actor?->country,
+                    $this->payor->actor?->country,
+                    $this->sharedPayor->actor?->country,
                     $this->client->actor?->country_billing,
                     $this->sharedClient->actor?->country_billing
                 ]),
@@ -715,20 +750,20 @@ class Matter extends Model
 
         return collect([
             collect([
-                $this->payer->actor?->name,
-                $this->sharedPayer->actor?->name,
+                $this->payor->actor?->name,
+                $this->sharedPayor->actor?->name,
                 $this->client->actor?->name,
                 $this->sharedClient->actor?->name
             ]),
             collect([
-                $this->payer->actor?->address,
-                $this->sharedPayer->actor?->address,
+                $this->payor->actor?->address,
+                $this->sharedPayor->actor?->address,
                 $this->client->actor?->address,
                 $this->sharedClient->actor?->address
             ]),
             collect([
-                $this->payer->actor?->country,
-                $this->sharedPayer->actor?->country,
+                $this->payor->actor?->country,
+                $this->sharedPayor->actor?->country,
                 $this->client->actor?->country,
                 $this->sharedClient->actor?->country
             ])

--- a/app/Services/DocumentMergeService.php
+++ b/app/Services/DocumentMergeService.php
@@ -125,8 +125,6 @@ class DocumentMergeService
             ...$this->getActorsFields(),
         ]);
 
-        dd($this->matter->annuityAgent);
-
         $complex = ['Priority', 'Client_Address', 'Billing_Address', 'Inventor_Addresses', 'Owner', 'Agent'];
         return [
             'simple' => $selects->except($complex)->toArray(),

--- a/app/Services/DocumentMergeService.php
+++ b/app/Services/DocumentMergeService.php
@@ -161,7 +161,7 @@ class DocumentMergeService
                     $agent->address,
                     $agent->country
                 ])->filter()->implode("\n") : "",
-            'Agent_Ref' => $agent->pivot->actor_ref,
+            'Agent_Ref' => $agent->actor_ref,
         ]);
     }
 

--- a/app/Services/DocumentMergeService.php
+++ b/app/Services/DocumentMergeService.php
@@ -116,16 +116,16 @@ class DocumentMergeService
                     ])->filter()->implode("\n");
                 })->implode("\n\n"),
             'Owner' => $this->matter->getOwnerName(),
-            'Responsible' => $this->matter->responsibles
-                ->first()
-                ->name,
-            'Writer' => $this->matter->writers
-                ->first()
+            'Responsible' => $this->matter->responsibleActor
+                ?->name,
+            'Writer' => $this->matter->writer
                 ?->name,
         ])->merge([
             ...$this->getTaskRules(),
             ...$this->getActorsFields(),
         ]);
+
+        dd($this->matter->annuityAgent);
 
         $complex = ['Priority', 'Client_Address', 'Billing_Address', 'Inventor_Addresses', 'Owner', 'Agent'];
         return [
@@ -150,7 +150,7 @@ class DocumentMergeService
 
     private function getAgentFields(): \Illuminate\Support\Collection
     {
-        $agent = $this->matter->agents->merge($this->matter->sharedAgents)->first();
+        $agent = $this->matter->agent;
 
         if (!$agent) {
             return collect();
@@ -185,20 +185,17 @@ class DocumentMergeService
 
     private function getPrimaryAgentFields(): \Illuminate\Support\Collection
     {
-        $primaryAgent = $this->matter->agents->merge($this->matter->sharedAgents)->first();
-        return $this->getActorDetails($primaryAgent, 'Primary_Agent');
+        return $this->getActorDetails($this->matter->agent, 'Primary_Agent');
     }
 
     private function getSecondaryAgentFields(): \Illuminate\Support\Collection
     {
-        $secondaryAgent = $this->matter->secondaryAgents->merge($this->matter->sharedSecondaryAgents)->first();
-        return $this->getActorDetails($secondaryAgent, 'Secondary_agent');
+        return $this->getActorDetails($this->matter->secondaryAgent, 'Secondary_agent');
     }
 
     private function getAnnuityAgentFields(): \Illuminate\Support\Collection
     {
-        $annuityAgent = $this->matter->annuityAgents->merge($this->matter->sharedAnnuityAgents)->first();
-        return $this->getActorDetails($annuityAgent, 'Annuity_Agent');
+        return $this->getActorDetails($this->matter->annuityAgent, 'Annuity_Agent');
     }
 
     private function getClientFields(): \Illuminate\Support\Collection

--- a/app/Traits/BelongsToManyActors.php
+++ b/app/Traits/BelongsToManyActors.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Actor;
+use App\Models\ActorPivot;
+
+trait BelongsToManyActors
+{
+    /**
+     * Define a belongsToMany relationship with the Actor model, including container relations.
+     *
+     * This method returns a belongsToMany relationship with the actors table,
+     * using the ActorPivot model and including additional pivot fields.
+     * If no relationship exists for the given role, it returns a relationship
+     * with the container actors that are shared.
+     *
+     * @param string $role The role to filter the actors by.
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany The belongsToMany relationship.
+     */
+    public function belongsToManyActors(string $role)
+    {
+        // Define the belongsToMany relationship with the actors table
+        $request = $this->belongsToMany(Actor::class, 'matter_actor_lnk', 'matter_id', 'actor_id')
+            ->using(ActorPivot::class)
+            ->withPivot('role', 'display_order', 'shared', 'actor_ref')
+            ->wherePivot('role', $role);
+
+        // If no relationship exists for the given role, return the container actors that are shared
+        if(!$request->exists()) {
+            return $this->belongsToMany(Actor::class, 'matter_actor_lnk', 'matter_id', 'actor_id', 'container_id')
+                ->using(ActorPivot::class)
+                ->withPivot('role', 'display_order', 'shared', 'actor_ref')
+                ->wherePivot('role', $role)
+                ->wherePivot('shared', 1);
+        }
+
+        return $request;
+    }
+}

--- a/app/Traits/HasOneActorThroughActorPivot.php
+++ b/app/Traits/HasOneActorThroughActorPivot.php
@@ -4,6 +4,7 @@ namespace App\Traits;
 
 use App\Models\Actor;
 use App\Models\ActorPivot;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Trait HasOneActorThroughActorPivot
@@ -27,11 +28,13 @@ trait HasOneActorThroughActorPivot
     {
         // Define the hasOneThrough relationship with the actors table
         $request = $this->hasOneThrough(Actor::class, ActorPivot::class, 'matter_id', 'id', 'id', 'actor_id')
+            ->select('actor.*', 'matter_actor_lnk.*')
             ->where('role', $role);
 
         // If no relationship exists for the given role, return the container actors that are shared
         if(!$request->exists()) {
             $request = $this->hasOneThrough(Actor::class, ActorPivot::class, 'matter_id', 'id', 'container_id', 'actor_id')
+                ->select('actor.*', 'matter_actor_lnk.*')
                 ->where('role', $role)
                 ->where('shared', 1);
         }

--- a/app/Traits/HasOneActorThroughActorPivot.php
+++ b/app/Traits/HasOneActorThroughActorPivot.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Actor;
+use App\Models\ActorPivot;
+
+/**
+ * Trait HasOneActorThroughActorPivot
+ *
+ * Provides a method to define a one-to-one relationship through a pivot table.
+ */
+trait HasOneActorThroughActorPivot
+{
+    /**
+     * Define a one-to-one relationship through a pivot table with a specific role.
+     *
+     * This method returns a hasOneThrough relationship with the actors table,
+     * using the ActorPivot model and filtering by the specified role.
+     * If no relationship exists for the given role, it returns a relationship
+     * with the container actors that are shared.
+     *
+     * @param string $role The role to filter the relationship by.
+     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough The hasOneThrough relationship.
+     */
+    public function hasOneActorThroughActorPivot(string $role): \Illuminate\Database\Eloquent\Relations\HasOneThrough
+    {
+        // Define the hasOneThrough relationship with the actors table
+        $request = $this->hasOneThrough(Actor::class, ActorPivot::class, 'matter_id', 'id', 'id', 'actor_id')
+            ->where('role', $role);
+
+        // If no relationship exists for the given role, return the container actors that are shared
+        if(!$request->exists()) {
+            $request = $this->hasOneThrough(Actor::class, ActorPivot::class, 'matter_id', 'id', 'container_id', 'actor_id')
+                ->where('role', $role)
+                ->where('shared', 1);
+        }
+
+        return $request;
+    }
+}


### PR DESCRIPTION
Hello,

I noticed that some actor-related data was missing, so I’ve added the missing pieces and also took the opportunity to clean up the `DocumentMergeService`.

I also renamed the `payer()` method to `payor()` which fits more the naming convention in the project.

While reviewing the code, I realized that the `DocumentMergeService` could potentially benefit from further refactoring. Specifically, I suggest splitting it into two separate services:

- One dedicated to data collection.
- Another focused on template processing.

This would help improve modularity, readability, and maintainability.

Let me know your thoughts or if you have suggestions for other improvements!

Thanks!