### PR TITLE
DocumentMergeService: Fix complex fields issue + Typo in Secondary_Agent + Rewrote hasActorsFromRole query

### DIFF
--- a/app/Models/Matter.php
+++ b/app/Models/Matter.php
@@ -93,7 +93,7 @@ class Matter extends Model
      *
      * @return \App\Models\Actor|null
      */
-    public function clientFromLnk(): ?Actor
+    public function clientFromLnk(): ?MatterActors
     {
         return $this->getActorFromRole('CLI');
     }
@@ -104,14 +104,9 @@ class Matter extends Model
      *
      * @return \App\Models\Actor|null
      */
-    public function payor()
+    public function payor(): ?MatterActors
     {
         return $this->getActorFromRole('PAY');
-    }
-
-    public function sharedPayor()
-    {
-        return $this->hasOne(MatterActors::class)->whereRoleCode('PAY')->whereShared(1)->withDefault();
     }
 
     public function delegate()
@@ -163,7 +158,7 @@ class Matter extends Model
      *
      * @return \App\Models\Actor|null
      */
-    public function agent(): ?Actor
+    public function agent(): ?MatterActors
     {
         return $this->getActorFromRole('AGT');
     }
@@ -174,7 +169,7 @@ class Matter extends Model
      *
      * @return \App\Models\Actor|null
      */
-    public function secondaryAgent(): ?Actor
+    public function secondaryAgent(): ?MatterActors
     {
         return $this->getActorFromRole('AGT2');
     }
@@ -185,7 +180,7 @@ class Matter extends Model
      *
      * @return \App\Models\Actor|null
      */
-    public function writer(): ?Actor
+    public function writer(): ?MatterActors
     {
         return $this->getActorFromRole('WRT');
     }
@@ -196,7 +191,7 @@ class Matter extends Model
      *
      * @return \App\Models\Actor|null
      */
-    public function annuityAgent(): ?Actor
+    public function annuityAgent(): ?MatterActors
     {
         return $this->getActorFromRole('ANN');
     }
@@ -741,11 +736,11 @@ class Matter extends Model
         // Collect the address parts from the payor and client, filter out null values, and ensure uniqueness.
         $addressParts = collect([
             $payor?->name,
-            $payor?->address,
-            $payor?->country,
+            $payor?->actor?->address,
+            $payor?->actor?->country,
             $client?->name,
-            $client?->address_billing ?? $client?->address,
-            $client?->country_billing ?? $client?->country,
+            $client?->actor?->address_billing ?? $client?->actor?->address,
+            $client?->actor?->country_billing ?? $client?->actor?->country,
         ])->filter()->unique();
 
         // Concatenate the address parts into a single string separated by newline characters.

--- a/app/Traits/HasActorsFromRole.php
+++ b/app/Traits/HasActorsFromRole.php
@@ -4,6 +4,7 @@ namespace App\Traits;
 
 use App\Models\Actor;
 use App\Models\ActorPivot;
+use App\Models\MatterActors;
 
 trait HasActorsFromRole
 {
@@ -20,19 +21,9 @@ trait HasActorsFromRole
      */
     public function getActorsFromRole(string $role): \Illuminate\Database\Eloquent\Collection
     {
-        return Actor::query()
-            ->join('matter_actor_lnk', 'actor.id', '=', 'matter_actor_lnk.actor_id')
-            ->where('matter_actor_lnk.role', $role)
-            ->where(function ($query) {
-                $query
-                    ->where('matter_actor_lnk.matter_id', $this->id)
-                    ->orWhere(function ($query) {
-                        $query
-                            ->where('matter_actor_lnk.matter_id', $this->container_id)
-                            ->where('matter_actor_lnk.shared', 1);
-                    });
-            })
-            ->select('actor.*', 'matter_actor_lnk.*')
+        return $this->actors()
+            ->with('actor')
+            ->where('role_code', $role)
             ->get();
     }
 
@@ -47,7 +38,7 @@ trait HasActorsFromRole
      * @param string $role The role to filter the relationship by.
      * @return \App\Models\Actor|null The hasOneThrough relationship.
      */
-    public function getActorFromRole(string $role): ?Actor
+    public function getActorFromRole(string $role): ?MatterActors
     {
         return $this->getActorsFromRole($role)->first();
     }


### PR DESCRIPTION
All the addresses of the new actors added since PR #145 aren't formatted correctly (except `${Client_Address}`).  
This is because these addresses are missing from the "complex" array. I’ve added them to ensure proper formatting, especially handling `\n`.  

I also fixed the replacement of `\n` since, in some cases, the line return wouldn’t apply. I added an explicit `\n`, which works as expected (see [Laracasts discussion](https://laracasts.com/discuss/channels/laravel/break-line-in-string-inserted-in-word-document)).  

Additionally, there was a typo in the "Secondary_agent" field—it should be "Secondary_Agent". This has now been corrected.  

Finally, I rewrote the query in `getActorsFromRole` to use `MatterActors`. Thanks to code splitting, this wasn’t too difficult to implement.  