### PR TITLE
fix(HasActorsFromRole, Matter): improve sorting logic

### DIFF
--- a/app/Models/Matter.php
+++ b/app/Models/Matter.php
@@ -755,12 +755,12 @@ class Matter extends Model
      */
     public function getOwnerName(): ?string
     {
-        $owners = $this->owners()->pluck('name')->unique()->sort();
+        $owners = $this->owners()->pluck('name')->unique();
 
         if ($owners->isNotEmpty()) {
             return $owners->implode("\n");
         }
 
-        return $this->applicantsFromLnk()->pluck('name')->unique()->sort()->implode("\n");
+        return $this->applicantsFromLnk()->pluck('name')->unique()->implode("\n");
     }
 }

--- a/app/Traits/HasActorsFromRole.php
+++ b/app/Traits/HasActorsFromRole.php
@@ -24,6 +24,7 @@ trait HasActorsFromRole
         return $this->actors()
             ->with('actor')
             ->where('role_code', $role)
+            ->orderBy('display_order')
             ->get();
     }
 


### PR DESCRIPTION
Add `orderBy('display_order')` to actor fetching in `HasActorsFromRole` for consistent ordering. Remove unnecessary `sort()` calls in `Matter` model to optimize and prevent redundant sorting during owner name retrieval.

Fixed an inconsistent sorting in owners (and actors) when trying to merge document. Fixed it by using the `display_order` column to have a consistent ordering between front-office and document merge.