### PR TITLE
Add Basic JSON API Support to Index Actions in Controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Homestead.yaml
 .env
 /nbproject/private/
 /config/renewal.php
+.DS_Store

--- a/app/Http/Controllers/ActorController.php
+++ b/app/Http/Controllers/ActorController.php
@@ -27,7 +27,14 @@ class ActorController extends Controller
                 $actor = $actor->where('warn', 1);
                 break;
         }
-        $actorslist = $actor->with('company')->orderby('name')->paginate(21);
+
+        $query = $actor->with('company')->orderby('name');
+
+        if ($request->wantsJson()) {
+            return response()->json($query->get());
+        }
+
+        $actorslist = $query->paginate(21);
         $actorslist->appends($request->input())->links();
 
         return view('actor.index', compact('actorslist'));

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -24,6 +24,10 @@ class CategoryController extends Controller
 
         $categories = $category->get();
 
+        if ($request->wantsJson()) {
+            return response()->json($categories);
+        }
+
         return view('category.index', compact('categories'));
     }
 

--- a/app/Http/Controllers/ClassifierTypeController.php
+++ b/app/Http/Controllers/ClassifierTypeController.php
@@ -24,6 +24,10 @@ class ClassifierTypeController extends Controller
 
         $types = $classifierType->with(['category:code,category'])->get();
 
+        if ($request->wantsJson()) {
+            return response()->json($types);
+        }
+
         return view('classifier_type.index', compact('types'));
     }
 

--- a/app/Http/Controllers/DefaultActorController.php
+++ b/app/Http/Controllers/DefaultActorController.php
@@ -43,6 +43,10 @@ class DefaultActorController extends Controller
         }
         $default_actors = $default_actor->with(['roleInfo:code,name', 'actor:id,name', 'client:id,name', 'category:code,category', 'country:iso,name'])->get();
 
+        if ($request->wantsJson()) {
+            return response()->json($default_actors);
+        }
+
         return view('default_actor.index', compact('default_actors'));
     }
 

--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -28,7 +28,13 @@ class DocumentController extends Controller
             $template_classes = $template_classes->whereLike('notes', $Notes.'%');
         }
 
-        $template_classes = $template_classes->orderby('name')->simplePaginate(config('renewal.general.paginate') == 0 ? 25 : intval(config('renewal.general.paginate')));
+        $query = $template_classes->orderby('name');
+
+        if ($request->wantsJson()) {
+            return response()->json($query->get());
+        }
+
+        $template_classes = $query->simplePaginate(config('renewal.general.paginate') == 0 ? 25 : intval(config('renewal.general.paginate')));
         $template_classes->appends($request->input())->links();
 
         return view('documents.index', compact('template_classes'));

--- a/app/Http/Controllers/EventNameController.php
+++ b/app/Http/Controllers/EventNameController.php
@@ -22,6 +22,10 @@ class EventNameController extends Controller
             $ename = $ename->whereJsonLike('name', $Name);
         }
 
+        if ($request->wantsJson()) {
+            return response()->json($ename->get());
+        }
+
         $enameslist = $ename->paginate(21);
         $enameslist->appends($request->input())->links();
 

--- a/app/Http/Controllers/FeeController.php
+++ b/app/Http/Controllers/FeeController.php
@@ -25,7 +25,14 @@ class FeeController extends Controller
                 }
             }
         }
-        $fees = $fees->orderBy('for_category')->orderBy('for_country')->orderBy('qt')->simplePaginate(config('renewal.general.paginate') == 0 ? 25 : intval(config('renewal.general.paginate')));
+
+        $query = $fees->orderBy('for_category')->orderBy('for_country')->orderBy('qt');
+
+        if ($request->wantsJson()) {
+            return response()->json($query->get());
+        }
+
+        $fees = $query->simplePaginate(config('renewal.general.paginate') == 0 ? 25 : intval(config('renewal.general.paginate')));
 
         return view('fee.index', compact('fees'));
     }

--- a/app/Http/Controllers/MatterController.php
+++ b/app/Http/Controllers/MatterController.php
@@ -38,25 +38,31 @@ class MatterController extends Controller
     {
         $filters = $request->except(
             [
-                'display_with',
-                'page',
-                'filter',
-                'value',
-                'sortkey',
-                'sortdir',
-                'tab',
-                'include_dead',
-            ]
-        );
+            'display_with',
+            'page',
+            'filter',
+            'value',
+            'sortkey',
+            'sortdir',
+            'tab',
+            'include_dead',
+        ]);
 
-        $matters = Matter::filter(
+        $query = Matter::filter(
             $request->input('sortkey', 'id'),
             $request->input('sortdir', 'desc'),
             $filters,
             $request->display_with,
             $request->include_dead
-        )->simplePaginate(25);
-        $matters->withQueryString()->links(); // Keep URL parameters in the paginator links
+        );
+
+        if ($request->wantsJson()) {
+            $matters = $query->with('events.info')->get();
+            return response()->json($matters);
+        }
+
+        $matters = $query->simplePaginate(25);
+        $matters->withQueryString()->links();  // Keep URL parameters in the paginator links
 
         return view('matter.index', compact('matters'));
     }

--- a/app/Http/Controllers/MatterTypeController.php
+++ b/app/Http/Controllers/MatterTypeController.php
@@ -24,6 +24,10 @@ class MatterTypeController extends Controller
 
         $matter_types = $type->get();
 
+        if ($request->wantsJson()) {
+            return response()->json($matter_types);
+        }
+
         return view('type.index', compact('matter_types'));
     }
 

--- a/app/Http/Controllers/RenewalController.php
+++ b/app/Http/Controllers/RenewalController.php
@@ -96,6 +96,17 @@ class RenewalController extends Controller
             $renewals->orderByDesc('due_date');
         }
 
+        if ($request->wantsJson()) {
+            $renewals = $renewals->get();
+            $renewals->transform(function ($ren) {
+                $this->adjustFees($ren, $cost, $fee);
+                $ren->cost = $cost;
+                $ren->fee = $fee;
+                return $ren;
+            });
+            return response()->json($renewals);
+        }
+
         $renewals = $renewals->simplePaginate(config('renewal.general.paginate', 25));
 
         // Adjust the cost and fee of each renewal based on customized settings
@@ -106,7 +117,7 @@ class RenewalController extends Controller
             return $ren;
         });
         
-$renewals->appends($request->input())->links(); // Keep URL parameters in the paginator links
+        $renewals->appends($request->input())->links(); // Keep URL parameters in the paginator links
         return view('renewals.index', compact('renewals', 'step', 'invoice_step'));
     }
 

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -25,6 +25,10 @@ class RoleController extends Controller
 
         $roles = $role->get();
 
+        if ($request->wantsJson()) {
+            return response()->json($roles);
+        }
+
         return view('role.index', compact('roles'));
     }
 

--- a/app/Http/Controllers/RuleController.php
+++ b/app/Http/Controllers/RuleController.php
@@ -57,11 +57,16 @@ class RuleController extends Controller
             $rule = $rule->whereLike('for_origin', "{$Origin}%");
         }
         
-        $ruleslist = $rule->with(['country:iso,name', 'trigger:code,name', 'category:code,category', 'origin:iso,name', 'type:code,type', 'taskInfo:code,name'])
+        $query = $rule->with(['country:iso,name', 'trigger:code,name', 'category:code,category', 'origin:iso,name', 'type:code,type', 'taskInfo:code,name'])
             ->select('task_rules.*')
             ->join('event_name AS t', 't.code', '=', 'task_rules.task')
-            ->orderByRaw("t.name->>'$.$baseLocale'")
-            ->paginate(21);
+            ->orderByRaw("t.name->>'$.$baseLocale'");
+
+        if ($request->wantsJson()) {
+            return response()->json($query->get());
+        }
+
+        $ruleslist = $query->paginate(21);
         $ruleslist->appends($request->input())->links();
 
         return view('rule.index', compact('ruleslist'));

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -47,7 +47,13 @@ class TaskController extends Controller
                 });
         }
 
-        $tasks = $tasks->orderBy('due_date')->simplePaginate(18)
+        $query = $tasks->orderBy('due_date');
+
+        if ($request->wantsJson()) {
+            return response()->json($query->get());
+        }
+
+        $tasks = $query->simplePaginate(18)
             ->appends($request->input());
 
         return view('task.index', compact('tasks', 'isrenewals'));

--- a/app/Http/Controllers/TemplateMemberController.php
+++ b/app/Http/Controllers/TemplateMemberController.php
@@ -42,7 +42,13 @@ class TemplateMemberController extends Controller
             $template_members = $template_members->where('style', 'LIKE', "$Style%");
         }
 
-        $template_members = $template_members->orderBy('summary')->simplePaginate(config('renewal.general.paginate') == 0 ? 25 : intval(config('renewal.general.paginate')));
+        $query = $template_members->orderBy('summary');
+
+        if ($request->wantsJson()) {
+            return response()->json($query->get());
+        }
+
+        $template_members = $query->simplePaginate(config('renewal.general.paginate') == 0 ? 25 : intval(config('renewal.general.paginate')));
         $template_members->appends($request->input())->links();
 
         return view('template-members.index', compact('template_members'));

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -19,7 +19,14 @@ class UserController extends Controller
         if ($request->filled('Name')) {
             $user = $user->where('name', 'like', $request->Name . '%');
         }
-        $userslist = $user->with('company')->orderby('name')->paginate(21);
+
+        $query = $user->with('company')->orderby('name');
+
+        if ($request->wantsJson()) {
+            return response()->json($query->get());
+        }
+
+        $userslist = $query->paginate(21);
         $userslist->appends($request->input())->links();
 
         return view('user.index', compact('userslist'));


### PR DESCRIPTION
This adds basic JSON response support to index() methods in several controllers. If the request has an Accept: application/json header, a full unpaginated dataset is returned as JSON. HTML behavior remains unchanged. This is a first step toward API support.