### PR TITLE
Database Query Fixes and MariaDB Compatibility Improvement

### DIFF
--- a/app/Console/Commands/RenewrSync.php
+++ b/app/Console/Commands/RenewrSync.php
@@ -219,7 +219,10 @@ class RenewrSync extends Command
 
             $task = $matter->tasks()
                 ->where('task.code', 'REN')
-                ->whereRaw("CAST(task.detail->>'$.en' AS UNSIGNED) = ?", [$renewal->renewalYearNumber])
+                ->whereRaw(
+                    "CAST(JSON_UNQUOTE(JSON_EXTRACT(task.detail, '$.\"en\"')) AS UNSIGNED) = ?",
+                    [$renewal->renewalYearNumber]
+                )
                 ->first();
 
             if ($task) {

--- a/app/Http/Controllers/RuleController.php
+++ b/app/Http/Controllers/RuleController.php
@@ -56,11 +56,11 @@ class RuleController extends Controller
         if (!is_null($Origin)) {
             $rule = $rule->whereLike('for_origin', "{$Origin}%");
         }
-        
+
         $query = $rule->with(['country:iso,name', 'trigger:code,name', 'category:code,category', 'origin:iso,name', 'type:code,type', 'taskInfo:code,name'])
             ->select('task_rules.*')
             ->join('event_name AS t', 't.code', '=', 'task_rules.task')
-            ->orderByRaw("t.name->>'$.$baseLocale'");
+            ->orderByRaw("JSON_UNQUOTE(JSON_EXTRACT(t.name, '$.\"{$baseLocale}\"'))");
 
         if ($request->wantsJson()) {
             return response()->json($query->get());

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -41,9 +41,14 @@ class TaskController extends Controller
         }
 
         if ($request->user_dashboard) {
-            $tasks->where('assigned_to', $request->user_dashboard)
-                ->orWhereHas('matter', function (Builder $q) use ($request) {
-                    $q->where('responsible', $request->user_dashboard);
+            $tasks
+                // Where needs encapsulation to avaid interference with others where conditions (caused by orWhere)
+                ->where(function (Builder $query) use ($request) {
+                    $query
+                        ->where('assigned_to', $request->user_dashboard)
+                        ->orWhereHas('matter', function (Builder $q) use ($request) {
+                            $q->where('responsible', $request->user_dashboard);
+                        });
                 });
         }
 

--- a/app/Models/Matter.php
+++ b/app/Models/Matter.php
@@ -363,7 +363,7 @@ class Matter extends Model
             'matter.country AS country',
             'matter.category_code AS Cat',
             'matter.origin',
-            DB::raw("GROUP_CONCAT(DISTINCT event_name.name->>'$.$baseLocale' SEPARATOR '|') AS Status"),
+            DB::raw("GROUP_CONCAT(DISTINCT JSON_UNQUOTE(JSON_EXTRACT(event_name.name, '$.\"$baseLocale\"')) SEPARATOR '|') AS Status"),
             DB::raw('MIN(status.event_date) AS Status_date'),
             DB::raw("GROUP_CONCAT(DISTINCT COALESCE(cli.display_name, clic.display_name, cli.name, clic.name) SEPARATOR '; ') AS Client"),
             DB::raw("GROUP_CONCAT(DISTINCT COALESCE(clilnk.actor_ref, cliclnk.actor_ref) SEPARATOR '; ') AS ClRef"),

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -104,7 +104,7 @@ class Task extends Model
         // The query is complex but optimized for performance by using joins and raw SQL for some calculations and conditions.
         return Matter::select([
             'task.id',
-            DB::raw("task.detail->>'$.en' AS detail"),
+            DB::raw("JSON_UNQUOTE(JSON_EXTRACT(task.detail, '$.\"en\"')) AS detail"),
             'task.due_date',
             'task.done',
             'task.done_date',
@@ -193,8 +193,8 @@ class Task extends Model
         // Fees
         ->leftJoin('fees', function($join) {
             $join->on('fees.for_country', 'matter.country')
-                 ->on('fees.for_category', 'matter.category_code')
-                 ->on(DB::raw("CAST(task.detail->>'$.en' AS UNSIGNED)"), 'fees.qt');
+                ->on('fees.for_category', 'matter.category_code')
+                ->on(DB::raw("CAST(JSON_UNQUOTE(JSON_EXTRACT(task.detail, '$.\"en\"')) AS UNSIGNED)"), 'fees.qt');
         })
         ->where('task.code', 'REN')
         ->groupBy('task.due_date')


### PR DESCRIPTION
## Overview
This PR fixes critical database query issues and enhances MariaDB compatibility across the application. The changes address query safety concerns, standardize JSON handling, and resolve migration failures on MariaDB installations.
## Changes
### TaskController Query Encapsulation
**Problem**: Query conditions were causing unintended interference due to improper `orWhere` usage without proper grouping.
**Solution**: Encapsulated conditional queries in closure-based `where` statements to prevent logical conflicts between different filter conditions.
**Impact**: Ensures accurate task filtering when using the user dashboard parameter, preventing query result contamination.
### JSON Handling Standardization
**Problem**: Inconsistent JSON extraction methods across the codebase using varying MySQL syntax patterns.
**Solution**: Standardized all JSON operations to use `JSON_UNQUOTE(JSON_EXTRACT(...))` pattern throughout the application.
**Files Updated**:
- RenewrSync command for renewal task queries
- RuleController for rule ordering logic
- Matter model for status aggregation
- Task model for detail extraction and fee calculations

**Impact**: Provides consistent JSON handling across all database operations and improves compatibility with different MySQL versions.
### Migration Enhancement for MariaDB Compatibility
**Why this change is necessary**: The original migration attempted to create functional indexes on JSON expressions using `CAST(... JSON_EXTRACT(...))`, which are not supported in MariaDB (any version) and only available in MySQL starting from version 8.0.13. This caused migration failures on setups using MariaDB or older MySQL versions.
**Affected versions**:
- **MariaDB**: All versions (10.2 to 10.11+)
- **MySQL**: Versions < 8.0.13

**Solution**: The migration now detects the database engine and applies the appropriate indexing strategy:
**For MariaDB**:
- Creates STORED generated columns (`column_en`, `column_fr`, etc.) using `JSON_UNQUOTE(JSON_EXTRACT(...))`
- Creates traditional indexes on those generated columns
- Uses STORED columns for better query performance compared to VIRTUAL columns

**For MySQL >= 8.0.13**:
- Retains functional indexes directly on JSON expressions
- Maintains existing optimization benefits

**Additional improvements**:
- Enhanced logging with clear progress tracking and error reporting
- Fully reversible `down()` method that properly handles both MariaDB and MySQL scenarios
- Improved rollback safety that extracts JSON data back to temporary columns and restores original schema
- Automatic database engine detection for seamless compatibility

This ensures the translatable attributes migration works reliably regardless of the SQL engine version in use, while maintaining optimal performance characteristics for each database type.
