### PR TITLE
Add orphaned foreign key handling in charset migration

### DIFF
--- a/database/migrations/2025_10_17_175605_convert_database_to_utf8mb4_0900_ai_ci.php
+++ b/database/migrations/2025_10_17_175605_convert_database_to_utf8mb4_0900_ai_ci.php
@@ -61,17 +61,64 @@ return new class extends Migration
                     ON DELETE {$fk->DELETE_RULE}
                 ");
             } catch (\Exception $e) {
-                // Print orphaned rows to help diagnose the referential integrity violation
+                // Find all orphaned rows for this FK
                 $orphans = DB::select("
-                    SELECT c.`{$fk->COLUMN_NAME}`
+                    SELECT c.`{$fk->COLUMN_NAME}` AS orphan_value
                     FROM `{$fk->TABLE_NAME}` c
                     LEFT JOIN `{$fk->REFERENCED_TABLE_NAME}` p
                         ON c.`{$fk->COLUMN_NAME}` = p.`{$fk->REFERENCED_COLUMN_NAME}`
                     WHERE p.`{$fk->REFERENCED_COLUMN_NAME}` IS NULL
-                    LIMIT 20
+                      AND c.`{$fk->COLUMN_NAME}` IS NOT NULL
                 ");
-                echo "ORPHANED ROWS in {$fk->TABLE_NAME}.{$fk->COLUMN_NAME}: " . json_encode($orphans) . "\n";
-                throw $e;
+
+                if (empty($orphans)) {
+                    throw $e; // Not an orphan issue — surface the original error
+                }
+
+                // Check whether the child column allows NULLs
+                $colInfo = DB::selectOne("
+                    SELECT IS_NULLABLE
+                    FROM information_schema.COLUMNS
+                    WHERE TABLE_SCHEMA = DATABASE()
+                      AND TABLE_NAME   = ?
+                      AND COLUMN_NAME  = ?
+                ", [$fk->TABLE_NAME, $fk->COLUMN_NAME]);
+
+                $isNullable = $colInfo && $colInfo->IS_NULLABLE === 'YES';
+                $orphanValues = implode(', ', array_column($orphans, 'orphan_value'));
+
+                if ($isNullable) {
+                    // Safe fix: NULL out the orphaned references, then retry
+                    DB::statement("
+                        UPDATE `{$fk->TABLE_NAME}` c
+                        LEFT JOIN `{$fk->REFERENCED_TABLE_NAME}` p
+                            ON c.`{$fk->COLUMN_NAME}` = p.`{$fk->REFERENCED_COLUMN_NAME}`
+                        SET c.`{$fk->COLUMN_NAME}` = NULL
+                        WHERE p.`{$fk->REFERENCED_COLUMN_NAME}` IS NULL
+                          AND c.`{$fk->COLUMN_NAME}` IS NOT NULL
+                    ");
+                    echo "[INFO] {$fk->TABLE_NAME}.{$fk->COLUMN_NAME}: "
+                        . count($orphans) . " orphan(s) set to NULL (orphaned values were: {$orphanValues})\n";
+
+                    // Retry adding the FK now that orphans are resolved
+                    DB::statement("
+                        ALTER TABLE `{$fk->TABLE_NAME}`
+                        ADD CONSTRAINT `{$fk->CONSTRAINT_NAME}`
+                        FOREIGN KEY (`{$fk->COLUMN_NAME}`)
+                        REFERENCES `{$fk->REFERENCED_TABLE_NAME}` (`{$fk->REFERENCED_COLUMN_NAME}`)
+                        ON UPDATE {$fk->UPDATE_RULE}
+                        ON DELETE {$fk->DELETE_RULE}
+                    ");
+                } else {
+                    // Column is NOT NULL — cannot auto-fix safely, refuse and explain
+                    echo "[ERROR] {$fk->TABLE_NAME}.{$fk->COLUMN_NAME} → "
+                        . "{$fk->REFERENCED_TABLE_NAME}.{$fk->REFERENCED_COLUMN_NAME}: "
+                        . count($orphans) . " orphan(s) found but column is NOT NULL — cannot auto-fix.\n"
+                        . "  Orphaned values: {$orphanValues}\n"
+                        . "  Manual options: (a) delete these rows, (b) insert the missing parent rows, "
+                        . "or (c) alter the column to allow NULLs first.\n";
+                    throw $e;
+                }
             }
         }
 

--- a/database/migrations/2025_10_17_175605_convert_database_to_utf8mb4_0900_ai_ci.php
+++ b/database/migrations/2025_10_17_175605_convert_database_to_utf8mb4_0900_ai_ci.php
@@ -51,14 +51,28 @@ return new class extends Migration
         // Step 5: Recreate all foreign keys
         foreach ($foreignKeys as $fk) {
             echo "Recreating FK: {$fk->CONSTRAINT_NAME} on {$fk->TABLE_NAME}\n";
-            DB::statement("
-                ALTER TABLE `{$fk->TABLE_NAME}`
-                ADD CONSTRAINT `{$fk->CONSTRAINT_NAME}`
-                FOREIGN KEY (`{$fk->COLUMN_NAME}`)
-                REFERENCES `{$fk->REFERENCED_TABLE_NAME}` (`{$fk->REFERENCED_COLUMN_NAME}`)
-                ON UPDATE {$fk->UPDATE_RULE}
-                ON DELETE {$fk->DELETE_RULE}
-            ");
+            try {
+                DB::statement("
+                    ALTER TABLE `{$fk->TABLE_NAME}`
+                    ADD CONSTRAINT `{$fk->CONSTRAINT_NAME}`
+                    FOREIGN KEY (`{$fk->COLUMN_NAME}`)
+                    REFERENCES `{$fk->REFERENCED_TABLE_NAME}` (`{$fk->REFERENCED_COLUMN_NAME}`)
+                    ON UPDATE {$fk->UPDATE_RULE}
+                    ON DELETE {$fk->DELETE_RULE}
+                ");
+            } catch (\Exception $e) {
+                // Print orphaned rows to help diagnose the referential integrity violation
+                $orphans = DB::select("
+                    SELECT c.`{$fk->COLUMN_NAME}`
+                    FROM `{$fk->TABLE_NAME}` c
+                    LEFT JOIN `{$fk->REFERENCED_TABLE_NAME}` p
+                        ON c.`{$fk->COLUMN_NAME}` = p.`{$fk->REFERENCED_COLUMN_NAME}`
+                    WHERE p.`{$fk->REFERENCED_COLUMN_NAME}` IS NULL
+                    LIMIT 20
+                ");
+                echo "ORPHANED ROWS in {$fk->TABLE_NAME}.{$fk->COLUMN_NAME}: " . json_encode($orphans) . "\n";
+                throw $e;
+            }
         }
 
         // Step 6: Recreate all triggers with new collation


### PR DESCRIPTION
## Summary
Enhanced the database charset migration to gracefully handle orphaned foreign key references that may exist due to data inconsistencies. The migration now detects constraint violations, identifies orphaned rows, and applies safe auto-fixes when possible.

## Key Changes
- Wrapped foreign key recreation in try-catch to detect constraint violations
- Added orphan detection query to identify rows with references to non-existent parent records
- Implemented intelligent auto-fix logic:
  - If the child column is nullable: automatically set orphaned references to NULL and retry the constraint
  - If the column is NOT NULL: refuse to auto-fix and provide detailed guidance for manual resolution
- Added informative logging to report orphan counts and values for both successful and failed fixes

## Implementation Details
- Orphan detection uses a LEFT JOIN to find child rows with no matching parent
- Column nullability is checked via `information_schema.COLUMNS` before attempting fixes
- When auto-fixing is possible, the migration updates orphaned rows and retries the foreign key constraint
- When auto-fixing is impossible, the migration logs specific orphaned values and suggests three manual resolution options: delete rows, insert missing parents, or alter the column to allow NULLs
- Original exceptions are re-thrown if orphans aren't the root cause or if the column cannot be safely modified

https://claude.ai/code/session_01GgKmTrixBGvFzzJjEhCqHE