### PR TITLE
Improve database migration robustness and fix null reference issues

### DIFF
--- a/app/Http/Controllers/MatterController.php
+++ b/app/Http/Controllers/MatterController.php
@@ -316,7 +316,9 @@ class MatterController extends Controller
             // Copy shared events from original matter
             $new_matter->priority()->createMany($parent_matter->priority->toArray());
             //$new_matter->parentFiling()->createMany($parent_matter->parentFiling->toArray());
-            $new_matter->filing()->save($parent_matter->filing->replicate());
+            if ($parent_matter->filing()->exists()) {
+                $new_matter->filing()->save($parent_matter->filing->replicate());
+            }
             if ($parent_matter->publication()->exists()) {
                 $new_matter->publication()->save($parent_matter->publication->replicate());
             }

--- a/database/migrations/2025_10_17_175605_convert_database_to_utf8mb4_0900_ai_ci.php
+++ b/database/migrations/2025_10_17_175605_convert_database_to_utf8mb4_0900_ai_ci.php
@@ -122,24 +122,25 @@ return new class extends Migration
             }
         }
 
+        // Steps 6 & 7: Recreate triggers and stored procedures/functions with new collation.
+        // MySQL requires SUPER privilege (or log_bin_trust_function_creators=1) to CREATE
+        // TRIGGER/FUNCTION/PROCEDURE when binary logging is enabled. Try once here for both steps.
+        $canRecreateStoredObjects = false;
+        try {
+            DB::statement('SET GLOBAL log_bin_trust_function_creators = 1');
+            $canRecreateStoredObjects = true;
+        } catch (\Exception $e) {
+            echo "[WARNING] Cannot set log_bin_trust_function_creators=1 (requires SUPER privilege). "
+                . "Trigger and stored routine recreation skipped — they remain with old collation. "
+                . "To fix, ask a DBA to run: SET GLOBAL log_bin_trust_function_creators = 1, "
+                . "then roll back and re-run this migration.\n";
+        }
+
         // Step 6: Recreate all triggers with new collation
-        $triggers = DB::select("SELECT TRIGGER_NAME, EVENT_MANIPULATION, EVENT_OBJECT_TABLE FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = '{$database}'");
+        if ($canRecreateStoredObjects) {
+            $triggers = DB::select("SELECT TRIGGER_NAME, EVENT_MANIPULATION, EVENT_OBJECT_TABLE FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = '{$database}'");
 
-        if (!empty($triggers)) {
-            // MySQL requires SUPER privilege (or log_bin_trust_function_creators=1) to CREATE TRIGGER
-            // when binary logging is enabled. Try to enable it; if we can't, leave triggers untouched.
-            $canRecreateTriggers = false;
-            try {
-                DB::statement('SET GLOBAL log_bin_trust_function_creators = 1');
-                $canRecreateTriggers = true;
-            } catch (\Exception $e) {
-                echo "[WARNING] Cannot set log_bin_trust_function_creators=1 (requires SUPER privilege). "
-                    . "Trigger recreation skipped — triggers remain with old collation. "
-                    . "To fix, ask a DBA to run: SET GLOBAL log_bin_trust_function_creators = 1, "
-                    . "then roll back and re-run this migration.\n";
-            }
-
-            if ($canRecreateTriggers) {
+            if (!empty($triggers)) {
                 // Store trigger definitions before dropping
                 $triggerDefinitions = [];
                 foreach ($triggers as $trigger) {
@@ -170,34 +171,36 @@ return new class extends Migration
         }
 
         // Step 7: Recreate stored procedures and functions
-        $procedures = DB::select("SELECT ROUTINE_NAME, ROUTINE_TYPE FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = '{$database}'");
+        if ($canRecreateStoredObjects) {
+            $procedures = DB::select("SELECT ROUTINE_NAME, ROUTINE_TYPE FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = '{$database}'");
 
-        $routineDefinitions = [];
-        foreach ($procedures as $procedure) {
-            $type = $procedure->ROUTINE_TYPE;
-            $name = $procedure->ROUTINE_NAME;
+            $routineDefinitions = [];
+            foreach ($procedures as $procedure) {
+                $type = $procedure->ROUTINE_TYPE;
+                $name = $procedure->ROUTINE_NAME;
 
-            if ($type === 'PROCEDURE') {
-                $result = DB::select("SHOW CREATE PROCEDURE `{$name}`");
-                $routineDefinitions[$name] = ['type' => 'PROCEDURE', 'sql' => $result[0]->{'Create Procedure'}];
-            } else {
-                $result = DB::select("SHOW CREATE FUNCTION `{$name}`");
-                $routineDefinitions[$name] = ['type' => 'FUNCTION', 'sql' => $result[0]->{'Create Function'}];
+                if ($type === 'PROCEDURE') {
+                    $result = DB::select("SHOW CREATE PROCEDURE `{$name}`");
+                    $routineDefinitions[$name] = ['type' => 'PROCEDURE', 'sql' => $result[0]->{'Create Procedure'}];
+                } else {
+                    $result = DB::select("SHOW CREATE FUNCTION `{$name}`");
+                    $routineDefinitions[$name] = ['type' => 'FUNCTION', 'sql' => $result[0]->{'Create Function'}];
+                }
             }
-        }
 
-        // Drop and recreate routines
-        foreach ($routineDefinitions as $name => $routine) {
-            DB::statement("DROP {$routine['type']} IF EXISTS `{$name}`");
+            // Drop and recreate routines
+            foreach ($routineDefinitions as $name => $routine) {
+                DB::statement("DROP {$routine['type']} IF EXISTS `{$name}`");
 
-            // Remove DEFINER clause
-            $sql = preg_replace('/DEFINER\s*=\s*`[^`]+`@`[^`]+`/i', '', $routine['sql']);
-            $sql = trim($sql);
-            if (!empty($sql)) {
-                DB::unprepared($sql);
-                echo "Recreated {$routine['type']}: {$name}\n";
-            } else {
-                echo "WARNING: Empty definition for {$routine['type']}: {$name}\n";
+                // Remove DEFINER clause
+                $sql = preg_replace('/DEFINER\s*=\s*`[^`]+`@`[^`]+`/i', '', $routine['sql']);
+                $sql = trim($sql);
+                if (!empty($sql)) {
+                    DB::unprepared($sql);
+                    echo "Recreated {$routine['type']}: {$name}\n";
+                } else {
+                    echo "WARNING: Empty definition for {$routine['type']}: {$name}\n";
+                }
             }
         }
     }

--- a/database/migrations/2025_10_17_175605_convert_database_to_utf8mb4_0900_ai_ci.php
+++ b/database/migrations/2025_10_17_175605_convert_database_to_utf8mb4_0900_ai_ci.php
@@ -61,17 +61,64 @@ return new class extends Migration
                     ON DELETE {$fk->DELETE_RULE}
                 ");
             } catch (\Exception $e) {
-                // Print orphaned rows to help diagnose the referential integrity violation
+                // Find all orphaned rows for this FK
                 $orphans = DB::select("
-                    SELECT c.`{$fk->COLUMN_NAME}`
+                    SELECT c.`{$fk->COLUMN_NAME}` AS orphan_value
                     FROM `{$fk->TABLE_NAME}` c
                     LEFT JOIN `{$fk->REFERENCED_TABLE_NAME}` p
                         ON c.`{$fk->COLUMN_NAME}` = p.`{$fk->REFERENCED_COLUMN_NAME}`
                     WHERE p.`{$fk->REFERENCED_COLUMN_NAME}` IS NULL
-                    LIMIT 20
+                      AND c.`{$fk->COLUMN_NAME}` IS NOT NULL
                 ");
-                echo "ORPHANED ROWS in {$fk->TABLE_NAME}.{$fk->COLUMN_NAME}: " . json_encode($orphans) . "\n";
-                throw $e;
+
+                if (empty($orphans)) {
+                    throw $e; // Not an orphan issue — surface the original error
+                }
+
+                // Check whether the child column allows NULLs
+                $colInfo = DB::selectOne("
+                    SELECT IS_NULLABLE
+                    FROM information_schema.COLUMNS
+                    WHERE TABLE_SCHEMA = DATABASE()
+                      AND TABLE_NAME   = ?
+                      AND COLUMN_NAME  = ?
+                ", [$fk->TABLE_NAME, $fk->COLUMN_NAME]);
+
+                $isNullable = $colInfo && $colInfo->IS_NULLABLE === 'YES';
+                $orphanValues = implode(', ', array_column($orphans, 'orphan_value'));
+
+                if ($isNullable) {
+                    // Safe fix: NULL out the orphaned references, then retry
+                    DB::statement("
+                        UPDATE `{$fk->TABLE_NAME}` c
+                        LEFT JOIN `{$fk->REFERENCED_TABLE_NAME}` p
+                            ON c.`{$fk->COLUMN_NAME}` = p.`{$fk->REFERENCED_COLUMN_NAME}`
+                        SET c.`{$fk->COLUMN_NAME}` = NULL
+                        WHERE p.`{$fk->REFERENCED_COLUMN_NAME}` IS NULL
+                          AND c.`{$fk->COLUMN_NAME}` IS NOT NULL
+                    ");
+                    echo "[INFO] {$fk->TABLE_NAME}.{$fk->COLUMN_NAME}: "
+                        . count($orphans) . " orphan(s) set to NULL (orphaned values were: {$orphanValues})\n";
+
+                    // Retry adding the FK now that orphans are resolved
+                    DB::statement("
+                        ALTER TABLE `{$fk->TABLE_NAME}`
+                        ADD CONSTRAINT `{$fk->CONSTRAINT_NAME}`
+                        FOREIGN KEY (`{$fk->COLUMN_NAME}`)
+                        REFERENCES `{$fk->REFERENCED_TABLE_NAME}` (`{$fk->REFERENCED_COLUMN_NAME}`)
+                        ON UPDATE {$fk->UPDATE_RULE}
+                        ON DELETE {$fk->DELETE_RULE}
+                    ");
+                } else {
+                    // Column is NOT NULL — cannot auto-fix safely, refuse and explain
+                    echo "[ERROR] {$fk->TABLE_NAME}.{$fk->COLUMN_NAME} → "
+                        . "{$fk->REFERENCED_TABLE_NAME}.{$fk->REFERENCED_COLUMN_NAME}: "
+                        . count($orphans) . " orphan(s) found but column is NOT NULL — cannot auto-fix.\n"
+                        . "  Orphaned values: {$orphanValues}\n"
+                        . "  Manual options: (a) delete these rows, (b) insert the missing parent rows, "
+                        . "or (c) alter the column to allow NULLs first.\n";
+                    throw $e;
+                }
             }
         }
 

--- a/database/migrations/2025_10_17_175605_convert_database_to_utf8mb4_0900_ai_ci.php
+++ b/database/migrations/2025_10_17_175605_convert_database_to_utf8mb4_0900_ai_ci.php
@@ -51,14 +51,28 @@ return new class extends Migration
         // Step 5: Recreate all foreign keys
         foreach ($foreignKeys as $fk) {
             echo "Recreating FK: {$fk->CONSTRAINT_NAME} on {$fk->TABLE_NAME}\n";
-            DB::statement("
-                ALTER TABLE `{$fk->TABLE_NAME}`
-                ADD CONSTRAINT `{$fk->CONSTRAINT_NAME}`
-                FOREIGN KEY (`{$fk->COLUMN_NAME}`)
-                REFERENCES `{$fk->REFERENCED_TABLE_NAME}` (`{$fk->REFERENCED_COLUMN_NAME}`)
-                ON UPDATE {$fk->UPDATE_RULE}
-                ON DELETE {$fk->DELETE_RULE}
-            ");
+            try {
+                DB::statement("
+                    ALTER TABLE `{$fk->TABLE_NAME}`
+                    ADD CONSTRAINT `{$fk->CONSTRAINT_NAME}`
+                    FOREIGN KEY (`{$fk->COLUMN_NAME}`)
+                    REFERENCES `{$fk->REFERENCED_TABLE_NAME}` (`{$fk->REFERENCED_COLUMN_NAME}`)
+                    ON UPDATE {$fk->UPDATE_RULE}
+                    ON DELETE {$fk->DELETE_RULE}
+                ");
+            } catch (\Exception $e) {
+                // Print orphaned rows to help diagnose the referential integrity violation
+                $orphans = DB::select("
+                    SELECT c.`{$fk->COLUMN_NAME}`
+                    FROM `{$fk->TABLE_NAME}` c
+                    LEFT JOIN `{$fk->REFERENCED_TABLE_NAME}` p
+                        ON c.`{$fk->COLUMN_NAME}` = p.`{$fk->REFERENCED_COLUMN_NAME}`
+                    WHERE p.`{$fk->REFERENCED_COLUMN_NAME}` IS NULL
+                    LIMIT 20
+                ");
+                echo "ORPHANED ROWS in {$fk->TABLE_NAME}.{$fk->COLUMN_NAME}: " . json_encode($orphans) . "\n";
+                throw $e;
+            }
         }
 
         // Step 6: Recreate all triggers with new collation

--- a/database/migrations/2025_10_17_175605_convert_database_to_utf8mb4_0900_ai_ci.php
+++ b/database/migrations/2025_10_17_175605_convert_database_to_utf8mb4_0900_ai_ci.php
@@ -123,34 +123,49 @@ return new class extends Migration
         }
 
         // Step 6: Recreate all triggers with new collation
-        // Get all triggers
         $triggers = DB::select("SELECT TRIGGER_NAME, EVENT_MANIPULATION, EVENT_OBJECT_TABLE FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = '{$database}'");
 
-        // Store trigger definitions before dropping
-        $triggerDefinitions = [];
-        foreach ($triggers as $trigger) {
-            $result = DB::select("SHOW CREATE TRIGGER `{$trigger->TRIGGER_NAME}`");
-            $triggerDefinitions[$trigger->TRIGGER_NAME] = $result[0]->{'SQL Original Statement'};
-        }
+        if (!empty($triggers)) {
+            // MySQL requires SUPER privilege (or log_bin_trust_function_creators=1) to CREATE TRIGGER
+            // when binary logging is enabled. Try to enable it; if we can't, leave triggers untouched.
+            $canRecreateTriggers = false;
+            try {
+                DB::statement('SET GLOBAL log_bin_trust_function_creators = 1');
+                $canRecreateTriggers = true;
+            } catch (\Exception $e) {
+                echo "[WARNING] Cannot set log_bin_trust_function_creators=1 (requires SUPER privilege). "
+                    . "Trigger recreation skipped — triggers remain with old collation. "
+                    . "To fix, ask a DBA to run: SET GLOBAL log_bin_trust_function_creators = 1, "
+                    . "then roll back and re-run this migration.\n";
+            }
 
-        // Drop all triggers
-        foreach ($triggers as $trigger) {
-            DB::statement("DROP TRIGGER IF EXISTS `{$trigger->TRIGGER_NAME}`");
-        }
+            if ($canRecreateTriggers) {
+                // Store trigger definitions before dropping
+                $triggerDefinitions = [];
+                foreach ($triggers as $trigger) {
+                    $result = DB::select("SHOW CREATE TRIGGER `{$trigger->TRIGGER_NAME}`");
+                    $triggerDefinitions[$trigger->TRIGGER_NAME] = $result[0]->{'SQL Original Statement'};
+                }
 
-        // Recreate triggers with new collation
-        DB::statement('SET character_set_client = utf8mb4');
-        DB::statement('SET collation_connection = utf8mb4_0900_ai_ci');
+                // Drop all triggers
+                foreach ($triggers as $trigger) {
+                    DB::statement("DROP TRIGGER IF EXISTS `{$trigger->TRIGGER_NAME}`");
+                }
 
-        foreach ($triggerDefinitions as $name => $definition) {
-            // Remove DEFINER clause if it causes issues
-            $definition = preg_replace('/DEFINER\s*=\s*`[^`]+`@`[^`]+`/i', '', $definition);
-            $definition = trim($definition);
-            if (!empty($definition)) {
-                DB::unprepared($definition);
-                echo "Recreated trigger: {$name}\n";
-            } else {
-                echo "WARNING: Empty definition for trigger: {$name}\n";
+                // Recreate triggers with new collation
+                DB::statement('SET character_set_client = utf8mb4');
+                DB::statement('SET collation_connection = utf8mb4_0900_ai_ci');
+
+                foreach ($triggerDefinitions as $name => $definition) {
+                    $definition = preg_replace('/DEFINER\s*=\s*`[^`]+`@`[^`]+`/i', '', $definition);
+                    $definition = trim($definition);
+                    if (!empty($definition)) {
+                        DB::unprepared($definition);
+                        echo "Recreated trigger: {$name}\n";
+                    } else {
+                        echo "WARNING: Empty definition for trigger: {$name}\n";
+                    }
+                }
             }
         }
 

--- a/resources/views/matter/createN.blade.php
+++ b/resources/views/matter/createN.blade.php
@@ -7,7 +7,7 @@
 	<input type="hidden" name="parent_id" value="{{ $parent_matter->id }}" />
 	<input type="hidden" name="responsible" value="{{ $parent_matter->responsible }}" />
 	<div id="ncountries">
-		@foreach( $parent_matter->countryInfo->natcountries as $iso => $name )
+		@foreach( $parent_matter->countryInfo?->natcountries ?? [] as $iso => $name )
 		<div class="input-group" id="country-{{ $iso }}">
 			<input type="hidden" name="ncountry[]" value="{{ $iso }}" />
 			<input type="text" class="form-control" readonly value="{{ $name }}" />

--- a/resources/views/matter/events.blade.php
+++ b/resources/views/matter/events.blade.php
@@ -61,7 +61,7 @@
             {{ $event->info->name }}
         @endif
       </td>
-      <td><input type="text" class="form-control noformat" name="event_date" value="{{ $event->event_date->isoFormat('L') }}"></td>
+      <td><input type="text" class="form-control noformat" name="event_date" value="{{ $event->event_date?->isoFormat('L') }}"></td>
       <td><input type="text" class="form-control noformat" size="16" name="detail" value="{{ $event->detail }}"></td>
       <td><input type="text" class="form-control noformat" name="notes" value="{{ $event->notes }}"></td>
       <td><input type="text" class="form-control noformat" size="10" name="alt_matter_id" data-ac="/matter/autocomplete" value="{{ $event->altMatter ? $event->altMatter->uid : '' }}"></td>


### PR DESCRIPTION
## Summary
This PR enhances the UTF-8MB4 database migration with better error handling for orphaned foreign key references, adds privilege checks for stored object recreation, and fixes several null reference issues in controllers and views.

## Key Changes

### Database Migration (`convert_database_to_utf8mb4_0900_ai_ci.php`)
- **Foreign Key Recreation**: Wrapped FK recreation in try-catch to detect and handle orphaned rows
  - Automatically NULLs out orphaned references if the column allows NULLs
  - Provides detailed error messages and manual remediation steps for NOT NULL columns
  - Logs orphaned values for audit purposes
- **Privilege Handling**: Added check for `log_bin_trust_function_creators` privilege before attempting to recreate triggers and stored procedures
  - Gracefully skips trigger/routine recreation if SUPER privilege is unavailable
  - Provides clear guidance for DBAs on how to resolve the issue
- **Code Organization**: Wrapped trigger and stored procedure recreation in conditional blocks to prevent errors when privileges are insufficient

### Controller (`MatterController.php`)
- **Null Safety**: Added existence check before attempting to replicate parent matter's filing relationship
  - Prevents errors when parent matter has no associated filing record

### Views
- **Blade Template Safety** (`createN.blade.php`):
  - Changed `$parent_matter->countryInfo->natcountries` to use null-safe operator: `$parent_matter->countryInfo?->natcountries ?? []`
  - Prevents errors when countryInfo relationship doesn't exist
- **Event Date Formatting** (`events.blade.php`):
  - Changed `$event->event_date->isoFormat('L')` to use null-safe operator: `$event->event_date?->isoFormat('L')`
  - Handles cases where event_date is null

## Implementation Details
- The FK orphan detection uses a LEFT JOIN to identify rows with references to non-existent parent records
- Orphan handling is intelligent: only auto-fixes nullable columns, requiring manual intervention for NOT NULL constraints
- Migration now provides informative console output for all error conditions and remediation steps
- All null-safety improvements use PHP 8's null-safe operator (`?->`) for cleaner syntax

https://claude.ai/code/session_01PfnP3qdQv5SWrE5aNMogen